### PR TITLE
issues/30: check if terminal supports color before printing stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Most recent version is listed first.  
 
 
+## v0.0.5
+- check if terminal supports color before printing stack traces: https://github.com/komuw/kama/pull/31
+
 ## v0.0.4
 - Add ability to print stack traces: https://github.com/komuw/kama/pull/29
   The stack traces are colorized with different colors for your code, third-party libs & the Go stdlib/runtime.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
-	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
+	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d
 	golang.org/x/tools v0.1.8
 )
 

--- a/stack.go
+++ b/stack.go
@@ -178,9 +178,5 @@ func noColor() bool {
 
 	fd := os.Stdout.Fd()
 	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
-	if err == nil {
-		return true
-	}
-
-	return false
+	return err == nil
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -26,5 +26,20 @@ func b() []string {
 
 // c calls social networks to get network graphs
 func c() []string {
+	d()
 	return getStackTrace()
 }
+
+func d() {
+	stackp()
+}
+
+// func Test_stackp(t *testing.T) {
+// 	t.Run("test-stackp", func(t *testing.T) {
+// 		c := qt.New(t)
+
+// 		got := d()
+
+// 		c.Assert(got[1], qt.Contains, "func a() []string {")
+// 	})
+// }

--- a/stack_test.go
+++ b/stack_test.go
@@ -26,20 +26,15 @@ func b() []string {
 
 // c calls social networks to get network graphs
 func c() []string {
-	d()
 	return getStackTrace()
+}
+
+func Test_stackp(t *testing.T) {
+	t.Run("test-stackp", func(t *testing.T) {
+		d()
+	})
 }
 
 func d() {
 	stackp()
 }
-
-// func Test_stackp(t *testing.T) {
-// 	t.Run("test-stackp", func(t *testing.T) {
-// 		c := qt.New(t)
-
-// 		got := d()
-
-// 		c.Assert(got[1], qt.Contains, "func a() []string {")
-// 	})
-// }


### PR DESCRIPTION
## What(What have you changed/added/removed?)
- check if terminal supports color before printing stack traces

## Why(Why did you change/add/remove it?)
- Fixes: https://github.com/komuw/kama/issues/30
